### PR TITLE
Add python requirements file

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,18 +2,24 @@
 Unfortunately these scripts are only compatible with Windows at the moment. 
 Pull requests are however welcome!
 
-## Import notice
-If you follow the steps below, you'll likelly get an error during the chaco installation in step 2.  
-This is due to a new issue tracked here: https://github.com/enthought/chaco/issues/910
-Before performing the steps below, follow these steps: https://github.com/enthought/chaco/issues/910#issuecomment-2065335367
-
 ## Requirements - Windows
 1) install c++ build tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/, select :
 - C++ CMake tools for Windows (it will select MSVC 2022)
 - Testing tools core features
 - Windows 10 SDK
 
-2) Install python and the required modules
+2) Create python virtual environment and activate it
 ```
-pip install pyqt5 chaco stm32loader pyserial scipy keyboard
+python -m venv venv
+venv\Scripts\activate
+```
+
+3) Install the required python modules
+```
+pip install -r requirements.txt
+```
+
+4) Load the GUI
+```
+python .\_start.py
 ```

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,8 @@
+numpy<2
+git+https://github.com/enthought/enable.git@84b611dcc329c7558f5512b861fb8e002f90f39f
+git+https://github.com/capn-freako/chaco@28eb0bc020142616d986a6242a3cac8d4b604f4a
+pyqt5
+stm32loader
+pyserial
+scipy
+keyboard


### PR DESCRIPTION
Given the current issues with chaco and enable, I found it much easier to use a python requirements file and install those two packages from the git hash.

Another caveat was that this script does not work with Numpy v2 so that also needed to be specified.