### PR TITLE
Add macOS support for Python scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,9 +1,30 @@
 # Python Scripts
-Unfortunately these scripts are only compatible with Windows at the moment. 
-Pull requests are however welcome!
+
+GUI tool for flashing, monitoring and configuring the CDM324 sensor board.
+
+## Requirements - macOS
+
+1) Create python virtual environment and activate it
+```bash
+python3 -m venv venv
+source venv/bin/activate
+```
+
+2) Install the required python modules
+```bash
+pip install -r requirements.txt
+```
+
+3) Load the GUI
+```bash
+python3 _start.py
+```
+
+Or simply double-click `start.command`.
 
 ## Requirements - Windows
-1) install c++ build tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/, select :
+
+1) Install C++ build tools from https://visualstudio.microsoft.com/visual-cpp-build-tools/, select:
 - C++ CMake tools for Windows (it will select MSVC 2022)
 - Testing tools core features
 - Windows 10 SDK

--- a/scripts/_start.py
+++ b/scripts/_start.py
@@ -1,243 +1,269 @@
-from time import gmtime, strftime, localtime, sleep
+#!/usr/bin/env python
+"""CDM324 Monitoring Tool - macOS-friendly GUI."""
+
 from configparser import ConfigParser
-from stream_visualizer import *
-from cdm324_device import *
+from stream_visualizer import stream_vis_start
+from cdm324_device import cdm324_device, list_serial_ports
 from subprocess import run
-try:
-	from tkinter import filedialog
-	import tkFont as tkfont
-	import Tkinter as tk
-	import ttk
-except ImportError:
-	from tkinter import font as tkfont
-	from tkinter import filedialog
-	import tkinter.ttk as ttk
-	import tkinter as tk
-import serial
-import cmath
-import math
-import sys
+from tkinter import filedialog, font as tkfont
+import tkinter.ttk as ttk
+import tkinter as tk
+import os
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_PATH = os.path.join(SCRIPT_DIR, "config.ini")
+
+# Colors
+BG = "#1e1e2e"
+BG_CARD = "#2a2a3d"
+FG = "#cdd6f4"
+FG_DIM = "#6c7086"
+ACCENT = "#89b4fa"
+GREEN = "#a6e3a1"
+RED = "#f38ba8"
+YELLOW = "#f9e2af"
+SURFACE = "#313244"
 
 
 class CDM324MonitorApp(tk.Tk):
-	def scan_available_com_ports(self):
-		# Create a list of possible com ports
-		ports = ['COM%s' % (i + 1) for i in range(2,256)]
+	def __init__(self):
+		super().__init__()
+		self.title("CDM324 Speed Sensor")
+		self.configure(bg=BG)
+		self.resizable(False, False)
+		self.bind("<Escape>", lambda e: self.quit())
 
-		# Try to open them to see which ones are actually available
-		available_ports = []
-		for port in ports:
-			try:
-				s = serial.Serial(port)
-				s.close()
-				available_ports.append(port)
-			except (OSError, serial.SerialException):
-				pass
-				
-		# Return what we got
-		return available_ports
-		
-	def select_update_file(self):
-		# Query user
-		file_path = filedialog.askopenfilename(filetypes=[("Binary files", "*.bin")])
-		
-		# Update string and store config
-		self.update_file_path.set(file_path)
-		self.config.set("main", "update_file", file_path)
-		with open('config.ini', 'w') as f:
-			self.config.write(f)
-	
-	def switch_speed_units(self):
-		if self.kmh == False:
-			self.refresh_speed_button.config(text="Switch to MPH")
-			self.config.set("main", "kmh", "1")
-			self.kmh = True
-		else:
-			self.refresh_speed_button.config(text="Switch to km/h")
+		# State
+		self.no_ports_det_msg_disp = False
+		self.disable_access_to_dev = False
+		self.connected_to_cdm = False
+		self.current_com_ports = []
+		self.com_port = ""
+		self.device = cdm324_device()
+
+		# Config
+		self.config = ConfigParser()
+		self.config.read(CONFIG_PATH)
+		if not self.config.has_section("main"):
+			self.config.add_section("main")
+		if not self.config.has_option("main", "update_file"):
+			self.config.set("main", "update_file", "")
+		if not self.config.has_option("main", "kmh"):
 			self.config.set("main", "kmh", "0")
 			self.kmh = False
-		with open('config.ini', 'w') as f:
-			self.config.write(f)			
-			
-	def flash_update_file(self):		
-		# Check for stm32loader presence
+		else:
+			self.kmh = self.config.get("main", "kmh") != "0"
+
+		self._build_ui()
+		self.com_port_monitor()
+		self.speed_query()
+
+	def _build_ui(self):
+		pad = {"padx": 16, "pady": 8}
+
+		# --- Connection section ---
+		conn_frame = tk.Frame(self, bg=BG_CARD, highlightbackground=SURFACE, highlightthickness=1)
+		conn_frame.grid(row=0, column=0, sticky="ew", padx=16, pady=(16, 4))
+
+		tk.Label(conn_frame, text="CONNECTION", font=("Helvetica", 10), fg=FG_DIM, bg=BG_CARD).grid(
+			row=0, column=0, sticky="w", padx=12, pady=(10, 2)
+		)
+
+		self.status_indicator = tk.Label(conn_frame, text="\u25cf", font=("Helvetica", 14), fg=RED, bg=BG_CARD)
+		self.status_indicator.grid(row=1, column=0, sticky="w", padx=(12, 4), pady=4)
+
+		self.connect_status_label = tk.Label(
+			conn_frame, text="Not Connected", font=("Helvetica", 13), fg=FG, bg=BG_CARD
+		)
+		self.connect_status_label.grid(row=1, column=1, sticky="w", pady=4)
+
+		self.com_port_var = tk.StringVar()
+		self.com_port_choice = ttk.Combobox(
+			conn_frame, textvariable=self.com_port_var, state="readonly", values=[], width=28
+		)
+		self.com_port_choice.grid(row=1, column=2, padx=(20, 12), pady=4)
+
+		# Bottom padding
+		tk.Frame(conn_frame, bg=BG_CARD, height=8).grid(row=2, column=0, columnspan=3)
+
+		# --- Speed display ---
+		speed_frame = tk.Frame(self, bg=BG_CARD, highlightbackground=SURFACE, highlightthickness=1)
+		speed_frame.grid(row=1, column=0, sticky="ew", padx=16, pady=4)
+		speed_frame.grid_columnconfigure(0, weight=1)
+
+		tk.Label(speed_frame, text="SPEED", font=("Helvetica", 10), fg=FG_DIM, bg=BG_CARD).grid(
+			row=0, column=0, sticky="w", padx=12, pady=(10, 0)
+		)
+
+		self.speed_label = tk.Label(
+			speed_frame, text="---", font=("Menlo", 48, "bold"), fg=ACCENT, bg=BG_CARD, anchor="center"
+		)
+		self.speed_label.grid(row=1, column=0, pady=(4, 4))
+
+		self.unit_label = tk.Label(
+			speed_frame, text="km/h" if self.kmh else "mph", font=("Helvetica", 14), fg=FG_DIM, bg=BG_CARD
+		)
+		self.unit_label.grid(row=2, column=0, pady=(0, 10))
+
+		unit_btn = tk.Button(
+			speed_frame, text="Switch Unit", font=("Helvetica", 11),
+			fg=BG, bg=ACCENT, activebackground=ACCENT, activeforeground=BG,
+			relief="flat", padx=16, pady=4, command=self.switch_speed_units
+		)
+		unit_btn.grid(row=1, column=1, rowspan=2, padx=(0, 12))
+
+		# --- Tools section ---
+		tools_frame = tk.Frame(self, bg=BG_CARD, highlightbackground=SURFACE, highlightthickness=1)
+		tools_frame.grid(row=2, column=0, sticky="ew", padx=16, pady=4)
+
+		tk.Label(tools_frame, text="TOOLS", font=("Helvetica", 10), fg=FG_DIM, bg=BG_CARD).grid(
+			row=0, column=0, sticky="w", padx=12, pady=(10, 4), columnspan=3
+		)
+
+		debug_btn = tk.Button(
+			tools_frame, text="Stream Visualizer", font=("Helvetica", 11),
+			fg=BG, bg=GREEN, activebackground=GREEN, activeforeground=BG,
+			relief="flat", padx=16, pady=6, command=self.start_debug_tool
+		)
+		debug_btn.grid(row=1, column=0, padx=12, pady=(0, 12))
+
+		# Firmware update row
+		self.update_file_path = tk.StringVar(value=self.config.get("main", "update_file"))
+		fw_entry = tk.Entry(
+			tools_frame, textvariable=self.update_file_path, font=("Menlo", 11),
+			bg=SURFACE, fg=FG, insertbackground=FG, relief="flat", width=30
+		)
+		fw_entry.grid(row=2, column=0, columnspan=2, padx=12, pady=(0, 4), sticky="ew")
+
+		btn_row = tk.Frame(tools_frame, bg=BG_CARD)
+		btn_row.grid(row=3, column=0, columnspan=3, padx=12, pady=(0, 12))
+
+		sel_btn = tk.Button(
+			btn_row, text="Select Firmware", font=("Helvetica", 11),
+			fg=FG, bg=SURFACE, activebackground=SURFACE, activeforeground=FG,
+			relief="flat", padx=12, pady=4, command=self.select_update_file
+		)
+		sel_btn.pack(side="left", padx=(0, 8))
+
+		flash_btn = tk.Button(
+			btn_row, text="Flash Firmware", font=("Helvetica", 11),
+			fg=BG, bg=YELLOW, activebackground=YELLOW, activeforeground=BG,
+			relief="flat", padx=12, pady=4, command=self.flash_update_file
+		)
+		flash_btn.pack(side="left")
+
+		# --- Log section ---
+		log_frame = tk.Frame(self, bg=BG_CARD, highlightbackground=SURFACE, highlightthickness=1)
+		log_frame.grid(row=3, column=0, sticky="ew", padx=16, pady=(4, 16))
+
+		tk.Label(log_frame, text="LOG", font=("Helvetica", 10), fg=FG_DIM, bg=BG_CARD).grid(
+			row=0, column=0, sticky="w", padx=12, pady=(10, 4)
+		)
+
+		self.log_output_text = tk.Text(
+			log_frame, width=60, height=6, wrap=tk.WORD,
+			font=("Menlo", 11), bg=SURFACE, fg=FG, insertbackground=FG,
+			relief="flat", borderwidth=0, padx=8, pady=8
+		)
+		self.log_output_text.grid(row=1, column=0, padx=12, pady=(0, 12), sticky="ew")
+
+	def output_to_console(self, message):
+		self.log_output_text.insert("end", message + "\n")
+		self.log_output_text.see(tk.END)
+		self.update_idletasks()
+		self.update()
+
+	def switch_speed_units(self):
+		self.kmh = not self.kmh
+		self.config.set("main", "kmh", "1" if self.kmh else "0")
+		self.unit_label.config(text="km/h" if self.kmh else "mph")
+		with open(CONFIG_PATH, "w") as f:
+			self.config.write(f)
+
+	def select_update_file(self):
+		file_path = filedialog.askopenfilename(filetypes=[("Binary files", "*.bin")])
+		if file_path:
+			self.update_file_path.set(file_path)
+			self.config.set("main", "update_file", file_path)
+			with open(CONFIG_PATH, "w") as f:
+				self.config.write(f)
+
+	def flash_update_file(self):
 		data = run("stm32loader", capture_output=True, shell=True, text=True)
 		if "STM32LOADER_SERIAL_PORT" not in data.stderr:
 			self.output_to_console("stm32loader isn't installed")
 			return
-			
-		# Disconnect from device
+
 		self.disable_access_to_dev = True
 		self.device.disconnect()
-			
-		# Start flashing!
+
 		self.output_to_console("Flashing started...")
-		data = run("stm32loader -b 115200 -p " + self.com_port + " -e -w -v -s -f F3 " + self.update_file_path.get(), capture_output=True, shell=True, text=True)
-		
-		# Success?
+		data = run(
+			"stm32loader -b 115200 -p " + self.com_port + " -e -w -v -s -f F3 " + self.update_file_path.get(),
+			capture_output=True, shell=True, text=True,
+		)
+
 		if "Verification OK" in data.stdout:
-			self.output_to_console("Flashing succesfull!")
+			self.output_to_console("Flashing successful!")
 		else:
 			self.output_to_console("Flashing failed")
-		
-		# Reconnect to device
+
 		self.connected_to_cdm = False
 		self.disable_access_to_dev = False
-		
+
 	def start_debug_tool(self):
-		# Disable access to com port
 		self.disable_access_to_dev = True
-		self.speed_label.config(text="")
-		self.device.disconnect()
-		
-		# Force UI update
+		self.speed_label.config(text="---")
+		if self.connected_to_cdm:
+			self.device.disconnect()
 		self.update_idletasks()
 		self.update()
-		
-		# Launch debug tool
+
 		stream_vis_start(self.com_port)
-				
-		# Reconnect to device
+
 		self.connected_to_cdm = False
 		self.disable_access_to_dev = False
-		
+
 	def speed_query(self):
-		if self.disable_access_to_dev == False and self.connected_to_cdm != False:
-			if self.kmh == False:
-				self.speed_label.config(text=str(self.device.query_mph()) + " MPH")
-			else:
-				self.speed_label.config(text=str(self.device.query_kmh()) + " km/h")
-				
-		# Launch the same routine later
+		if not self.disable_access_to_dev and self.connected_to_cdm:
+			try:
+				if self.kmh:
+					val = self.device.query_kmh()
+					self.speed_label.config(text=f"{val:.1f}")
+				else:
+					val = self.device.query_mph()
+					self.speed_label.config(text=f"{val:.1f}")
+			except Exception:
+				self.speed_label.config(text="---")
 		self.after(500, self.speed_query)
-		
+
 	def com_port_monitor(self):
-		# No need if already connected
-		if self.connected_to_cdm == False:
-			# Get a list of available COM ports
-			self.current_com_ports = self.scan_available_com_ports()
-			self.com_port_choice['values'] = self.current_com_ports
-			
-			# Try to connect to device
+		if not self.connected_to_cdm:
+			self.current_com_ports = list_serial_ports()
+			self.com_port_choice["values"] = self.current_com_ports
+
 			if len(self.current_com_ports) == 0:
-				if self.no_ports_det_msg_disp == False:
-					self.output_to_console("No COM ports detected!")			
-					self.combostyle.theme_use('combostyle_red') 
+				if not self.no_ports_det_msg_disp:
+					self.output_to_console("No serial ports detected")
+					self.status_indicator.config(fg=RED)
 					self.no_ports_det_msg_disp = True
 			else:
-				# Set default value
+				self.no_ports_det_msg_disp = False
 				self.com_port_choice.current(0)
-				
-				# Go through the list
+
 				for com_port in self.current_com_ports:
-					# Connection attempt
 					(self.connected_to_cdm, cdm_version) = self.device.connect(com_port)
-					
-					# Success?
 					if self.connected_to_cdm:
-						# Set correct COM port selection, output to console received string
-						self.com_port_choice.current(self.current_com_ports.index(com_port))	
+						self.com_port_choice.set(com_port)
 						self.connect_status_label.config(text="Connected")
-						self.combostyle.theme_use('combostyle_green') 
+						self.status_indicator.config(fg=GREEN)
+						if isinstance(cdm_version, bytes):
+							cdm_version = cdm_version.decode(errors="replace")
 						self.output_to_console(cdm_version)
 						self.com_port = com_port
 						break
-		
-		# Launch the same routine in a second
+
 		self.after(1000, self.com_port_monitor)
-		
-	def output_to_console(self, message):
-		self.log_output_text.insert("end", message + "\r\n")
-		self.log_output_text.see(tk.END)
-		
-		# Force UI update
-		self.update_idletasks()
-		self.update()
-	
-	def __init__(self, *args, **kwargs):
-		tk.Tk.__init__(self, *args, **kwargs)
-		self.title_font = tkfont.Font(family='Helvetica', size=18, weight="bold")
-		self.configure(background='LightSteelBlue2')
-		self.title("CDM324 Monitoring Tool")
-		self.resizable(0,0)
-		self.focus_set()
-		self.bind("<Escape>", lambda e: e.widget.quit())
-		
-		# Vars
-		self.no_ports_det_msg_disp = False
-		self.disable_access_to_dev = False
-		self.connected_to_cdm = False
-		self.config = ConfigParser()
-		self.current_com_ports = []
-		self.com_port = ""
-		
-		# Read settings		
-		self.config.read("config.ini")
-		if self.config.has_section("main") == False:
-			self.config.add_section('main')
-		if self.config.has_option("main", "update_file") == False:
-			self.config.set("main", "update_file", "")
-		if self.config.has_option("main", "kmh") == False:
-			self.config.set("main", "kmh", "0")
-			self.kmh = False
-		else:
-			self.kmh = False if self.config.get('main', 'kmh') == "0" else True
-		
-		# Vars
-		self.monitoring_bool = False
-		self.log_file_opened = False
-		self.laser_temp_word = -1
-		self.log_counter = 0
-		self.polarity = 0
-		
-		# combobox style		
-		self.combostyle = ttk.Style()
-		self.combostyle.theme_create('combostyle_red', parent='alt', settings = {'TCombobox': {'configure': {'selectbackground': 'blue', 'fieldbackground': 'red', 'background': 'green' }}})
-		self.combostyle.theme_create('combostyle_green', parent='alt', settings = {'TCombobox': {'configure': {'selectbackground': 'blue', 'fieldbackground': 'green', 'background': 'green' }}})
-		
-		# Top left: connection status & com port list
-		self.connect_status_label = tk.Label(self, text="Not Connected", background="LightSteelBlue2", font=tkfont.Font(family='Helvetica', size=12, weight=tkfont.BOLD), anchor="e")
-		self.connect_status_label.grid(row=0, column=0, pady=(5,2), padx=5)
-		self.com_port_choice = ttk.Combobox(self, state="readonly", values=self.current_com_ports, width=20)
-		self.com_port_choice.grid(row=0, column=1, pady=(0,2), padx=5)
-		self.com_port_choice.set("")
-		
-		# Update file path
-		self.update_file_path = tk.StringVar()
-		self.update_file_path.set(self.config.get('main', 'update_file'))
-		self.update_file_path_entry = ttk.Entry(self, width="46", textvariable=self.update_file_path)
-		self.update_file_path_entry.grid(row=1, column=0, columnspan=2, pady=(5,2), padx=5)		
-				
-		# Update file action buttons
-		self.select_file_button = tk.Button(self, text="Select Firmware", font=tkfont.Font(family='Helvetica', size=9), width="18", command=lambda:[self.select_update_file()])
-		self.select_file_button.grid(row=2, column=0, pady=(5,2), padx=(15,15))		
-		self.update_fw_button = tk.Button(self, text="Update Firmware", font=tkfont.Font(family='Helvetica', size=9), width="18", command=lambda:[self.flash_update_file()])
-		self.update_fw_button.grid(row=2, column=1, pady=(5,2), padx=(15,15))	
-		
-		# Speed display
-		self.speed_label = tk.Label(self, text="", background="LightSteelBlue2", font=tkfont.Font(family='Helvetica', size=26, weight=tkfont.BOLD), anchor="e")
-		self.speed_label.grid(row=0, column=2, columnspan=2, rowspan=2, pady=(5,2), padx=5)
-				
-		# Speed action buttons
-		self.refresh_speed_button = tk.Button(self, text="Switch to km/h", font=tkfont.Font(family='Helvetica', size=9), width="18", command=lambda:[self.switch_speed_units()])
-		if self.kmh != False:
-			self.refresh_speed_button.config(text="Switch to MPH")
-		self.refresh_speed_button.grid(row=2, column=2, pady=(5,2), padx=(15,15))		
-		self.update_fw_button = tk.Button(self, text="Start Debug Tool", font=tkfont.Font(family='Helvetica', size=9), width="18", command=lambda:[self.start_debug_tool()])
-		self.update_fw_button.grid(row=2, column=3, pady=(5,2), padx=(15,15))	
-				
-		# Log output
-		self.log_output_text = tk.Text(self, width=80, height=8, wrap=tk.WORD)
-		self.log_output_text.grid(row=3, column=0, columnspan=4, pady=(15,20), padx = 20)
-		
-		# Blank cdm324 device
-		self.device = cdm324_device()
-		
-		# Trigger com ports monitor to trigger connection
-		self.com_port_monitor()
-		
-		# Trigger speed query
-		self.speed_query()
 
 
 if __name__ == "__main__":

--- a/scripts/cdm324_device.py
+++ b/scripts/cdm324_device.py
@@ -1,49 +1,58 @@
 import serial
+import serial.tools.list_ports
+import platform
 import time
+
+
+def list_serial_ports():
+	"""List available serial ports (cross-platform)."""
+	return [p.device for p in serial.tools.list_ports.comports()]
 
 
 class cdm324_device:
 	# Device constructor
 	def __init__(self):
 		pass
-		
+
 	# Disconnect from device
 	def disconnect(self):
 		self.serial.close()
-		
+
 	# Query speed
 	def query_kmh(self):
 		self.serial.write(b'k')
 		return float(self.serial.read_until(b'\n').decode().strip())/10
-		
+
 	# Query speed
 	def query_mph(self):
 		self.serial.write(b'm')
 		return float(self.serial.read_until(b'\n').decode().strip())/10
-		
+
 	# Connect to device
 	def connect(self, COM_port):
-		self.com_port = COM_port	
+		self.com_port = COM_port
 
-		# Open COM port
+		# Open serial port
 		self.serial = serial.Serial(self.com_port, 1000000)
-		self.serial.set_buffer_size(rx_size = 1000000, tx_size = 1000000)
-		
+		# set_buffer_size is only available on Windows
+		if platform.system() == "Windows":
+			self.serial.set_buffer_size(rx_size = 1000000, tx_size = 1000000)
+
 		# Disable RTS to release RESET
 		self.serial.rts = False
 		time.sleep(.1)
-		
+
 		# Did we get smth from device boot?
 		if self.serial.in_waiting > 5:
 			# Read input buffer
 			self.cdm324_version = self.serial.read(self.serial.in_waiting)
-			
+
 			# First bytes may be garbage
 			for i in range(len(self.cdm324_version)):
 				if self.cdm324_version[i] == ord('C'):
 					self.cdm324_version = self.cdm324_version[i:-2].decode('utf-8')
 					break
-			
+
 			# Return
 			return (True, self.cdm324_version)
 		else:

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,5 @@
-numpy<2
-git+https://github.com/enthought/enable.git@84b611dcc329c7558f5512b861fb8e002f90f39f
-git+https://github.com/capn-freako/chaco@28eb0bc020142616d986a6242a3cac8d4b604f4a
-pyqt5
-stm32loader
+numpy
+matplotlib
 pyserial
 scipy
-keyboard
+stm32loader

--- a/scripts/start.command
+++ b/scripts/start.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+source venv/bin/activate
+python3 _start.py

--- a/scripts/stream_visualizer.py
+++ b/scripts/stream_visualizer.py
@@ -1,286 +1,176 @@
 #!/usr/bin/env python
-# Needed to configure graphics library
-# Requires Enthought Tool Suite 4
-from traits.etsconfig.api import ETSConfig
-ETSConfig.toolkit = 'qt4'
+"""CDM324 Speed Sensor - Real-time Stream Visualizer (matplotlib version)."""
 
-# Data processing functions
-from numpy import zeros, linspace, short, fromstring, hstack, transpose
+from cdm324_device import list_serial_ports
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+from matplotlib.gridspec import GridSpec
 from scipy import fft
-
-# Enthought library imports
-from chaco.default_colormaps import hot
-from enable.api import Component, ComponentEditor
-from traits.api import HasTraits, Instance
-from traitsui.api import Item, Group, View, Handler
-from pyface.timer.api import Timer
-from time import sleep
-
-# Chaco imports
-from chaco.api import Plot, ArrayPlotData, HPlotContainer, VPlotContainer
-
-# Imports for core program
 import numpy as np
+import platform
 import datetime
-import keyboard
 import serial
-import array
 import sys
 
 # Number of ADC samples sent by the device
 NUM_SAMPLES = 1024
 # ADC sampling rate
 SAMPLING_RATE = 35714
-# Spectogram length in # of FFTs
+# Spectrogram length in # of FFTs
 SPECTROGRAM_LENGTH = 500
 # How many fft bins are sent by the platform
 FFT_LGTH_TRUNCATE = 150
 
 # Array for computing signal average
-adc_average_array = [0]*20
+adc_average_array = [0] * 20
 adc_average_fill_index = 0
 
 
-def _create_plot_component(obj):
-	# Time Series plot
-	times = linspace(0.0, float(NUM_SAMPLES) / SAMPLING_RATE, num=NUM_SAMPLES)
-	obj.time_data = ArrayPlotData(time=times)
-	empty_amplitude = zeros(NUM_SAMPLES)
-	obj.time_data.set_data("amplitude", empty_amplitude)
-	obj.time_plot = Plot(obj.time_data)
-	obj.time_plot.plot(("time", "amplitude"), name="Time", color="blue")
-	obj.time_plot.padding = 50
-	obj.time_plot.title = "Device Raw ADC Values"
-	obj.time_plot.index_axis.title = "Time (seconds)"
-	obj.time_plot.value_axis.title = "ADC word"
-	time_range = list(obj.time_plot.plots.values())[0][0].value_mapper.range
-	time_range.low = 0
-	time_range.high = 5000
-	
-	# Setup the device spectrum plot
-	frequencies = linspace(0.0, SAMPLING_RATE*0.02262295*FFT_LGTH_TRUNCATE/NUM_SAMPLES, num=FFT_LGTH_TRUNCATE)
-	obj.device_spectrum_data = ArrayPlotData(frequency=frequencies)
-	empty_amplitude = zeros(FFT_LGTH_TRUNCATE)
-	obj.device_spectrum_data.set_data("amplitude", empty_amplitude)
-	obj.device_spectrum_plot = Plot(obj.device_spectrum_data)
-	obj.device_spectrum_plot.plot(("frequency", "amplitude"), name="Device Spectrum", color="red", renderstyle='hold')
-	obj.device_spectrum_plot.padding = 50
-	obj.device_spectrum_plot.title = "Device Computed Speed Spectrum"
-	plot_rends = list(obj.device_spectrum_plot.plots.values())
-	spec_range = plot_rends[0][0].value_mapper.range
-	spec_range.low = 0.0
-	spec_range.high = 300000.0
-	obj.device_spectrum_plot.index_axis.title = "Speed (km/h)"
-	obj.device_spectrum_plot.value_axis.title = "Amplitude"
-	
-	# Setup the computer computed spectrum plot
-	if False:
-		frequencies = linspace(0.0, FFT_LGTH_TRUNCATE, num=FFT_LGTH_TRUNCATE)
-		obj.spectrum_data = ArrayPlotData(frequency=frequencies)
-		empty_amplitude = zeros(NUM_SAMPLES // 2)
-		obj.spectrum_data.set_data("amplitude", empty_amplitude)
-		obj.spectrum_plot = Plot(obj.spectrum_data)
-		obj.spectrum_plot.plot(("frequency", "amplitude"), name="Spectrum", color="red", renderstyle='hold')
-		obj.spectrum_plot.padding = 50
-		obj.spectrum_plot.title = "Spectrum"
-		plot_rends = list(obj.spectrum_plot.plots.values())
-		spec_range = plot_rends[0][0].value_mapper.range
-		spec_range.low = 0.0
-		spec_range.high = 200.0
-		obj.spectrum_plot.index_axis.title = "Frequency (Hz)"
-		obj.spectrum_plot.value_axis.title = "Amplitude"
+class CDM324Visualizer:
+	def __init__(self, com_port):
+		self.serial_initialized = False
+		self.ser = serial.Serial(com_port, 1000000)
+		if platform.system() == "Windows":
+			self.ser.set_buffer_size(rx_size=1000000, tx_size=1000000)
+		self.ser.rts = False
+		self.skip_low_freqs = False
 
-	# Spectrogram plot
-	spectrogram_data = zeros((FFT_LGTH_TRUNCATE, SPECTROGRAM_LENGTH))
-	obj.spectrogram_plotdata = ArrayPlotData()
-	obj.spectrogram_plotdata.set_data("imagedata", spectrogram_data)
-	spectrogram_plot = Plot(obj.spectrogram_plotdata)
-	max_time = float(SPECTROGRAM_LENGTH * NUM_SAMPLES) / SAMPLING_RATE
-	max_freq = float(SAMPLING_RATE*0.02262295*FFT_LGTH_TRUNCATE/NUM_SAMPLES)
-	spectrogram_plot.img_plot(
-		"imagedata",
-		name="Spectrogram",
-		xbounds=(0, max_time),
-		ybounds=(0, max_freq),
-		colormap=hot,
-	)
-	range_obj = spectrogram_plot.plots["Spectrogram"][0].value_mapper.range
-	range_obj.high = 130
-	range_obj.low = 0.0
-	spectrogram_plot.title = "Speed Spectrogram"
-	obj.spectrogram_plot = spectrogram_plot
+		# Time axis
+		self.times = np.linspace(0.0, float(NUM_SAMPLES) / SAMPLING_RATE, num=NUM_SAMPLES)
+		# Speed axis (km/h)
+		self.speeds = np.linspace(0.0, SAMPLING_RATE * 0.02262295 * FFT_LGTH_TRUNCATE / NUM_SAMPLES, num=FFT_LGTH_TRUNCATE)
+		# Spectrogram data
+		self.spectrogram_data = np.zeros((FFT_LGTH_TRUNCATE, SPECTROGRAM_LENGTH))
 
-	container = VPlotContainer()
-	container.add(obj.time_plot)
-	container.add(obj.device_spectrum_plot)
-	#container.add(obj.spectrum_plot)
-	container.add(spectrogram_plot)
-	return container
+		# Setup plots
+		self.fig = plt.figure(figsize=(12, 9))
+		self.fig.suptitle("CDM324 Speed Sensor", fontsize=14, fontweight="bold")
+		gs = GridSpec(3, 1, figure=self.fig, hspace=0.4)
 
-counter = 0
-skip_low_freqs = False
-# HasTraits class that supplies the callable for the timer event.
-class TimerController(HasTraits):
-	def onTimer(self, *args):
-		global platform_serial_initialized
-		global adc_average_fill_index
-		global adc_average_array
-		global counter
-		#print(counter)
-		counter += 1
-		
-		# Debug choices
-		sync_prot = True
-		
-		# keyboard shortcut pressed?
-		if keyboard.is_pressed("h") and skip_low_freqs == False:
-			platform_serial.write(b'h')
-		elif keyboard.is_pressed("r"):
-			platform_serial_initialized = False
-	
-		# Did we initialize our serial port?
-		if platform_serial_initialized == False:
-			if sync_prot:
-				# Stop stream, empty buffer
-				platform_serial.write(b's')
-				sleep(.1)
-				platform_serial.read(platform_serial.in_waiting)
-				platform_serial.reset_input_buffer()
-				# Start stream
-				platform_serial.write(b'a')
-				platform_serial_initialized = True
+		# Plot 1: Raw ADC
+		self.ax_time = self.fig.add_subplot(gs[0])
+		self.ax_time.set_title("Device Raw ADC Values")
+		self.ax_time.set_xlabel("Time (seconds)")
+		self.ax_time.set_ylabel("ADC word")
+		self.ax_time.set_ylim(0, 5000)
+		self.line_time, = self.ax_time.plot(self.times, np.zeros(NUM_SAMPLES), color="blue", linewidth=0.5)
+
+		# Plot 2: Speed Spectrum
+		self.ax_spectrum = self.fig.add_subplot(gs[1])
+		self.ax_spectrum.set_title("Device Computed Speed Spectrum")
+		self.ax_spectrum.set_xlabel("Speed (km/h)")
+		self.ax_spectrum.set_ylabel("Amplitude")
+		self.ax_spectrum.set_ylim(0, 300000)
+		self.line_spectrum, = self.ax_spectrum.step(self.speeds, np.zeros(FFT_LGTH_TRUNCATE), color="red", linewidth=0.5)
+
+		# Plot 3: Spectrogram
+		self.ax_spectrogram = self.fig.add_subplot(gs[2])
+		self.ax_spectrogram.set_title("Speed Spectrogram")
+		max_time = float(SPECTROGRAM_LENGTH * NUM_SAMPLES) / SAMPLING_RATE
+		max_speed = float(SAMPLING_RATE * 0.02262295 * FFT_LGTH_TRUNCATE / NUM_SAMPLES)
+		self.img = self.ax_spectrogram.imshow(
+			self.spectrogram_data,
+			aspect="auto",
+			origin="lower",
+			extent=[0, max_time, 0, max_speed],
+			cmap="hot",
+			vmin=0,
+			vmax=130,
+		)
+		self.ax_spectrogram.set_xlabel("Time (seconds)")
+		self.ax_spectrogram.set_ylabel("Speed (km/h)")
+
+		# Keyboard shortcuts via matplotlib key_press_event
+		self.fig.canvas.mpl_connect("key_press_event", self._on_key)
+
+	def _on_key(self, event):
+		if event.key == "h":
+			self.skip_low_freqs = not self.skip_low_freqs
+			if self.skip_low_freqs:
+				self.ser.write(b'h')
+				print("Low frequencies removed")
 			else:
-				platform_serial.read(platform_serial.in_waiting)				
-	
-		#sys.stdout.write(str(platform_serial.in_waiting) + " ")
-		# Buffer back log: skip one frame
-		if platform_serial.in_waiting > 2 * (NUM_SAMPLES*2 + FFT_LGTH_TRUNCATE*4):
-			platform_serial.read(NUM_SAMPLES*2 + FFT_LGTH_TRUNCATE*4)
+				self.ser.write(b'l')
+				print("Low frequencies restored")
+		elif event.key == "r":
+			self.serial_initialized = False
+			print("Resynchronizing...")
+
+	def _init_stream(self):
+		# Stop stream, empty buffer
+		self.ser.write(b's')
+		import time
+		time.sleep(0.1)
+		self.ser.read(self.ser.in_waiting)
+		self.ser.reset_input_buffer()
+		# Start stream
+		self.ser.write(b'a')
+		self.serial_initialized = True
+
+	def update(self, frame):
+		global adc_average_array, adc_average_fill_index
+
+		if not self.serial_initialized:
+			self._init_stream()
+
+		# Skip frames if buffer backs up
+		if self.ser.in_waiting > 2 * (NUM_SAMPLES * 2 + FFT_LGTH_TRUNCATE * 4):
+			self.ser.read(NUM_SAMPLES * 2 + FFT_LGTH_TRUNCATE * 4)
 			print(str(datetime.datetime.now()) + ": skipping one frame")
-		
-		# Get raw adc data (NUM_SAMPLES uint16_t)
-		raw_adc_data = platform_serial.read(NUM_SAMPLES*2)
-		dt = np.dtype(np.uint16)
-		dt = dt.newbyteorder('<')
-		raw_adc_data = np.frombuffer(raw_adc_data, dtype=dt)
-		self.time_data.set_data("amplitude", raw_adc_data)
-		
-		# Get FFT data
-		serial_fft_data = platform_serial.read(FFT_LGTH_TRUNCATE*4)
-		dt = np.dtype(np.single)
-		dt = dt.newbyteorder('<')
-		serial_fft_data = np.frombuffer(serial_fft_data, dtype=dt)
-		#print(max(serial_fft_data))
-		self.device_spectrum_data.set_data("amplitude", serial_fft_data)
-		
-		# debug
-		if False:
-			np.set_printoptions(threshold=np.inf)
-			arrayyy = np.frombuffer(raw_adc_data, dtype=dt)
-			print("Min: " + str(np.min(arrayyy)) + ", max: " + str(np.max(arrayyy)) + " at index " + " " . join(str(i) for i in np.where(arrayyy == np.max(arrayyy))))
-		
+
+		# Read raw ADC data (NUM_SAMPLES uint16_t)
+		raw_bytes = self.ser.read(NUM_SAMPLES * 2)
+		raw_adc_data = np.frombuffer(raw_bytes, dtype=np.dtype("<u2"))
+		self.line_time.set_ydata(raw_adc_data)
+
+		# Read FFT data (FFT_LGTH_TRUNCATE float32)
+		fft_bytes = self.ser.read(FFT_LGTH_TRUNCATE * 4)
+		serial_fft_data = np.frombuffer(fft_bytes, dtype=np.dtype("<f4"))
+		self.line_spectrum.set_ydata(serial_fft_data)
+
 		# Update average
 		adc_average_array[adc_average_fill_index] = np.mean(raw_adc_data)
 		adc_average_fill_index += 1
 		if adc_average_fill_index == len(adc_average_array):
-			adc_average_fill_index = 0		
-	
-		# Compute fft
-		normalized_data = np.array(raw_adc_data, copy=True)  
+			adc_average_fill_index = 0
+
+		# Compute FFT for spectrogram
+		normalized_data = np.array(raw_adc_data, dtype=np.float64)
 		normalized_data = (normalized_data - np.mean(adc_average_array)) / 2048
-		spectrum = abs(fft.fft(normalized_data))[: NUM_SAMPLES // 2]
+		spectrum = np.abs(fft.fft(normalized_data))[:NUM_SAMPLES // 2]
 		spectrum = spectrum[:FFT_LGTH_TRUNCATE]
-	
-		# We don't display computer computed fft data anymore
-		if False:
-			self.spectrum_data.set_data("amplitude", spectrum)
-			self.spectrum_plot.request_redraw()
-			
-		spectrogram_data = self.spectrogram_plotdata.get_data("imagedata")
-		spectrogram_data = hstack(
-			(spectrogram_data[:, 1:], transpose([spectrum]))
+
+		# Update spectrogram
+		self.spectrogram_data = np.hstack(
+			(self.spectrogram_data[:, 1:], spectrum.reshape(-1, 1))
 		)
-		self.spectrogram_plotdata.set_data("imagedata", spectrogram_data)
+		self.img.set_data(self.spectrogram_data)
 
+		return self.line_time, self.line_spectrum, self.img
 
-# ============================================================================
-# Attributes to use for the plot view.
-size = (1280, 1024)
-title = "CDM324 Speed Sensor"
+	def start(self):
+		self.anim = animation.FuncAnimation(
+			self.fig, self.update, interval=10, blit=False, cache_frame_data=False
+		)
+		plt.tight_layout()
+		plt.show()
+		self.ser.close()
 
-class CDM324Handler(Handler):
-	def closed(self, info, is_ok):
-		"""Handles a dialog-based user interface being closed by the user.
-		Overridden here to stop the timer once the window is destroyed.
-		"""
-		info.object.timer.Stop()
-		platform_serial.close()
-
-
-class CDM324(HasTraits):
-	timer = Instance(Timer)
-	plot = Instance(Component)
-	controller = Instance(TimerController, ())
-	
-	traits_view = View(
-		Group(Item("plot", editor=ComponentEditor(size=size), show_label=False),orientation="vertical",),
-		resizable=True,
-		title=title,
-		width=size[0],
-		height=size[1],
-		handler=CDM324Handler,)
-
-	def _plot_default(self):
-		return _create_plot_component(self.controller)
-
-	def edit_traits(self, *args, **kws):
-		# Start up the timer! We should do this only when the demo actually
-		# starts and not when the demo object is created.
-		self.timer = Timer(10, self.controller.onTimer)
-		return super(CDM324, self).edit_traits(*args, **kws)
-
-	def configure_traits(self, *args, **kws):
-		# Start up the timer! We should do this only when the demo actually
-		# starts and not when the demo object is created.
-		self.timer = Timer(10, self.controller.onTimer)
-		return super(CDM324, self).configure_traits(*args, **kws)
 
 def stream_vis_start(com_port):
-	global platform_serial_initialized
-	global platform_serial
-	
-	platform_serial_initialized = False
-	platform_serial = serial.Serial(com_port, 1000000)
-	platform_serial.set_buffer_size(rx_size = 1000000, tx_size = 1000000)
-	platform_serial.rts = False
-	
-	# Start GUI
-	popup = CDM324()
-	popup.configure_traits()	
+	vis = CDM324Visualizer(com_port)
+	vis.start()
+
 
 if __name__ == "__main__":
-	# Create a list of possible com ports
-	ports = ['COM%s' % (i + 1) for i in range(2,256)]
+	available_ports = list_serial_ports()
 
-	# Try to open them to see which ones are actually available
-	available_ports = []
-	for port in ports:
-		try:
-			s = serial.Serial(port)
-			s.close()
-			available_ports.append(port)
-		except (OSError, serial.SerialException):
-			pass
-			
-	# Did we find anything?
 	if len(available_ports) == 0:
-		print("No COM ports found")
+		print("No serial ports found")
 		sys.exit(0)
 
-	# Debug info
-	print("Opening" , available_ports[0])
-	print("Press 'h' to remove low frequencies")
-	print("Press 'r' in case data gets misaligned")
+	print("Opening", available_ports[0])
+	print("Press 'h' in the plot window to toggle low-frequency removal")
+	print("Press 'r' in the plot window to resynchronize data")
 
-	# Start main program
 	stream_vis_start(available_ports[0])


### PR DESCRIPTION
  - Replace Chaco/Enthought (Windows-only) with matplotlib
  - Replace keyboard module with matplotlib key events
  - Use pyserial.tools.list_ports instead of hardcoded COM ports
  - Add start.command for macOS double-click launch
  - Add requirements.txt
  - Skip set_buffer_size on non-Windows platforms